### PR TITLE
Contacts::Hotmail emails are not escaped and have some junk

### DIFF
--- a/contacts.gemspec
+++ b/contacts.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.description = "A universal interface to grab contact list information from various providers including Yahoo, AOL, Gmail, Hotmail, and Plaxo."
   s.has_rdoc = false
   s.authors = ["Lucas Carlson"]
-  s.files = ["LICENSE", "Rakefile", "README", "examples/grab_contacts.rb", "lib/contacts.rb", "lib/contacts/base.rb", "lib/contacts/json_picker.rb", "lib/contacts/gmail.rb", "lib/contacts/aol.rb", "lib/contacts/hotmail.rb", "lib/contacts/plaxo.rb", "lib/contacts/yahoo.rb"]
+  s.files = ["LICENSE", "Rakefile", "README", "examples/grab_contacts.rb", "lib/contacts.rb", "lib/contacts/base.rb", "lib/contacts/json_picker.rb", "lib/contacts/gmail.rb", "lib/contacts/aol.rb", "lib/contacts/hotmail.rb", "lib/contacts/plaxo.rb", "lib/contacts/yahoo.rb", "lib/contacts/mailru.rb"]
   s.add_dependency("json", ">= 1.1.1")
   s.add_dependency('gdata', '>= 1.1.1')
 end

--- a/lib/contacts/hotmail.rb
+++ b/lib/contacts/hotmail.rb
@@ -89,7 +89,7 @@ class Contacts
             # Grab info
             case c_info[1]
               when "e" # Email
-                build_contacts.last[1] = row.match(/#{email_match_text_beginning}(.*)#{email_match_text_end}/)[1]
+                build_contacts.last[1] = row.match(/#{email_match_text_beginning}(.*?)#{email_match_text_end}/)[1]
               when "dn" # Name
                 build_contacts.last[0] = row.match(/<a[^>]*>(.+)<\/a>/)[1]
             end
@@ -105,7 +105,9 @@ class Contacts
         build_contacts.each do |contact|
           unless contact[1].nil?
             # Only return contacts with email addresses
-            contact[1] = CGI::unescape(contact[1])
+            while contact[1] =~ /((%[0-9a-fA-F]{2})+)/i do
+              contact[1] = CGI::unescape(contact[1])
+            end
             @contacts << contact
           end
         end


### PR DESCRIPTION
Emails are HTML unescaped properly now. The junk at the end of the email address is removed. Gemspec file fixed for mailru support.
