### PR TITLE
Fix to broken Hotmail import

### DIFF
--- a/lib/contacts/hotmail.rb
+++ b/lib/contacts/hotmail.rb
@@ -45,6 +45,7 @@ class Contacts
         data, resp, cookies, forward, old_url = get(forward, cookies, old_url) + [forward]
       end
       
+      
       @domain = URI.parse(old_url).host
       @cookies = cookies
     rescue AuthenticationError => m
@@ -76,7 +77,7 @@ class Contacts
           resp, data = http.get(get_contact_list_url(index), "Cookie" => @cookies)
           
           email_match_text_beginning = Regexp.escape("http://m.mail.live.com/?rru=compose&amp;to=")
-          email_match_text_end = Regexp.escape("&amp;")
+          email_match_text_end = Regexp.escape("&amp;ru=")
           
           raw_html = resp.body.split("
 ").grep(/(?:e|dn)lk[0-9]+/)
@@ -105,7 +106,7 @@ class Contacts
         build_contacts.each do |contact|
           unless contact[1].nil?
             # Only return contacts with email addresses
-            contact[1] = CGI::unescape(contact[1])
+            contact[1] = CGI::unescape CGI::unescape(contact[1])
             @contacts << contact
           end
         end


### PR DESCRIPTION
I just pushed a new fix to my fork.  Hotmail imports were failing, so this should repair it.  Currently it's still throwing "Required field must not be blank" even if it's just a bad email/password.  I'm not exactly sure how to fix that one... but for my app, I just tell the user to check their email/pass for any error that's thrown anyhow.  At least now with a good email/pass it'll import again!
