### PR TITLE
AOL Import Issue & Contacts::Hotmail emails are not escaped

### DIFF
--- a/contacts.gemspec
+++ b/contacts.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.description = "A universal interface to grab contact list information from various providers including Yahoo, AOL, Gmail, Hotmail, and Plaxo."
   s.has_rdoc = false
   s.authors = ["Lucas Carlson"]
-  s.files = ["LICENSE", "Rakefile", "README", "examples/grab_contacts.rb", "lib/contacts.rb", "lib/contacts/base.rb", "lib/contacts/json_picker.rb", "lib/contacts/gmail.rb", "lib/contacts/aol.rb", "lib/contacts/hotmail.rb", "lib/contacts/plaxo.rb", "lib/contacts/yahoo.rb"]
+  s.files = ["LICENSE", "Rakefile", "README", "examples/grab_contacts.rb", "lib/contacts.rb", "lib/contacts/base.rb", "lib/contacts/json_picker.rb", "lib/contacts/gmail.rb", "lib/contacts/aol.rb", "lib/contacts/hotmail.rb", "lib/contacts/plaxo.rb", "lib/contacts/yahoo.rb", "lib/contacts/mailru.rb"]
   s.add_dependency("json", ">= 1.1.1")
   s.add_dependency('gdata', '>= 1.1.1')
 end

--- a/lib/contacts/aol.rb
+++ b/lib/contacts/aol.rb
@@ -6,10 +6,10 @@ class Contacts
     LOGIN_URL           = "https://my.screenname.aol.com/_cqr/login/login.psp"
     LOGIN_REFERER_URL   = "http://webmail.aol.com/"
     LOGIN_REFERER_PATH = "sitedomain=sns.webmail.aol.com&lang=en&locale=us&authLev=0&uitype=mini&loginId=&redirType=js&xchk=false"
-    AOL_NUM = "29970-343" # this seems to change each time they change the protocol
+    AOL_NUM = "32992-111" # this seems to change each time they change the protocol
     
-    CONTACT_LIST_URL    = "http://webmail.aol.com/#{AOL_NUM}/aim-2/en-us/Lite/ContactList.aspx?folder=Inbox&showUserFolders=False"
-    CONTACT_LIST_CSV_URL = "http://webmail.aol.com/#{AOL_NUM}/aim-2/en-us/Lite/ABExport.aspx?command=all"
+    CONTACT_LIST_URL    = "http://mail.aol.com/#{AOL_NUM}/aol-6/en-us/Lite/ContactList.aspx?folder=Inbox&showUserFolders=False"
+    CONTACT_LIST_CSV_URL = "http://mail.aol.com/#{AOL_NUM}/aol-6/en-us/Lite/ABExport.aspx?command=all"
     PROTOCOL_ERROR      = "AOL has changed its protocols, please upgrade this library first. If that does not work, dive into the code and submit a patch at http://github.com/cardmagic/contacts"
     
     def real_connect

--- a/lib/contacts/hotmail.rb
+++ b/lib/contacts/hotmail.rb
@@ -89,7 +89,7 @@ class Contacts
             # Grab info
             case c_info[1]
               when "e" # Email
-                build_contacts.last[1] = row.match(/#{email_match_text_beginning}(.*)#{email_match_text_end}/)[1]
+                build_contacts.last[1] = row.match(/#{email_match_text_beginning}(.*?)#{email_match_text_end}/)[1]
               when "dn" # Name
                 build_contacts.last[0] = row.match(/<a[^>]*>(.+)<\/a>/)[1]
             end
@@ -105,7 +105,9 @@ class Contacts
         build_contacts.each do |contact|
           unless contact[1].nil?
             # Only return contacts with email addresses
-            contact[1] = CGI::unescape(contact[1])
+            while contact[1] =~ /((%[0-9a-fA-F]{2})+)/i do
+              contact[1] = CGI::unescape(contact[1])
+            end
             @contacts << contact
           end
         end


### PR DESCRIPTION
Fixed AOL import issue - CSV::IllegalFormatError: CSV::IllegalFormatError

Also incorporated fix by PavelTyk Contacts::Hotmail emails are not escaped properly, e.g email was imported as "example%40gmail.com&amp;ru=http%3a%2f%2fmpeople.live.com%2fdefault.aspx%3fpg%3d0" instead of "example@gmail.com"
