### PR TITLE
Hpricot replaced with Nokogiri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 pkg/*
 test/accounts.yml
 nbproject/
+.rvmrc

--- a/contacts.gemspec
+++ b/contacts.gemspec
@@ -11,4 +11,5 @@ Gem::Specification.new do |s|
   s.files = ["LICENSE", "Rakefile", "README", "examples/grab_contacts.rb", "lib/contacts.rb", "lib/contacts/base.rb", "lib/contacts/json_picker.rb", "lib/contacts/gmail.rb", "lib/contacts/aol.rb", "lib/contacts/hotmail.rb", "lib/contacts/plaxo.rb", "lib/contacts/yahoo.rb"]
   s.add_dependency("json", ">= 1.1.1")
   s.add_dependency('gdata', '>= 1.1.1')
+  s.add_dependency('hpricot', '>= 0.8.4')
 end

--- a/contacts.gemspec
+++ b/contacts.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |s|
   s.files = ["LICENSE", "Rakefile", "README", "examples/grab_contacts.rb", "lib/contacts.rb", "lib/contacts/base.rb", "lib/contacts/json_picker.rb", "lib/contacts/gmail.rb", "lib/contacts/aol.rb", "lib/contacts/hotmail.rb", "lib/contacts/plaxo.rb", "lib/contacts/yahoo.rb"]
   s.add_dependency("json", ">= 1.1.1")
   s.add_dependency('gdata', '>= 1.1.1')
-  s.add_dependency('hpricot', '>= 0.8.4')
+  s.add_dependency('nokogiri', '>= 1.4.0')
 end

--- a/lib/contacts/aol.rb
+++ b/lib/contacts/aol.rb
@@ -1,5 +1,5 @@
 class Contacts
-  require 'hpricot'
+  require 'nokogiri'
   require 'csv'
   class Aol < Base
     URL                 = "http://www.aol.com/"
@@ -62,14 +62,14 @@ class Contacts
       until forward.nil?
         data, resp, cookies, forward, old_url = get(forward, cookies, old_url) + [forward]
       end
+
+      # parse data for <input name="usrd" value="2726212" type="hidden"> and add it to the postdata 
+      doc   = Nokogiri::HTML(data)
+      input = doc.css('input[name="usrd"]').first
+      postdata["usrd"] = input[:value] if input
+
  
-      doc = Hpricot(data)
-      (doc/:input).each do |input|
-        postdata["usrd"] = input.attributes["value"] if input.attributes["name"] == "usrd"
-      end
-      # parse data for <input name="usrd" value="2726212" type="hidden"> and add it to the postdata
- 
-      postdata["SNS_SC"] = cookie_hash_from_string(cookies)["SNS_SC"]
+      postdata["SNS_SC"]  = cookie_hash_from_string(cookies)["SNS_SC"]
       postdata["SNS_LDC"] = cookie_hash_from_string(cookies)["SNS_LDC"]
       postdata["LTState"] = cookie_hash_from_string(cookies)["LTState"]
       # raise data.inspect
@@ -114,10 +114,9 @@ class Contacts
         end
  
         # parse data and grab <input name="user" value="8QzMPIAKs2" type="hidden">
-        doc = Hpricot(data)
-        (doc/:input).each do |input|
-          postdata["user"] = input.attributes["value"] if input.attributes["name"] == "user"
-        end
+        doc   = Nokogiri::HTML(data)
+        input = doc.css('input[name="user"]').first
+        postdata["user"] = input[:value] if input
         
         data, resp, cookies, forward, old_url = get(CONTACT_LIST_CSV_URL, @cookies, CONTACT_LIST_URL) + [CONTACT_LIST_URL]
  

--- a/lib/contacts/aol.rb
+++ b/lib/contacts/aol.rb
@@ -5,12 +5,12 @@ class Contacts
     URL                 = "http://www.aol.com/"
     LOGIN_URL           = "https://my.screenname.aol.com/_cqr/login/login.psp"
     LOGIN_REFERER_URL   = "http://webmail.aol.com/"
-    LOGIN_REFERER_PATH = "sitedomain=sns.webmail.aol.com&lang=en&locale=us&authLev=0&uitype=mini&loginId=&redirType=js&xchk=false"
-    AOL_NUM = "29970-343" # this seems to change each time they change the protocol
+    LOGIN_REFERER_PATH  = "sitedomain=sns.webmail.aol.com&lang=en&locale=us&authLev=0&uitype=mini&loginId=&redirType=js&xchk=false"
     
-    CONTACT_LIST_URL    = "http://webmail.aol.com/#{AOL_NUM}/aim-2/en-us/Lite/ContactList.aspx?folder=Inbox&showUserFolders=False"
-    CONTACT_LIST_CSV_URL = "http://webmail.aol.com/#{AOL_NUM}/aim-2/en-us/Lite/ABExport.aspx?command=all"
-    PROTOCOL_ERROR      = "AOL has changed its protocols, please upgrade this library first. If that does not work, dive into the code and submit a patch at http://github.com/cardmagic/contacts"
+    AOL_NUM             = "33601-111" # this seems to change each time they change the protocol
+    CONTACT_LIST_URL     = "http://webmail1.mail.aol.com/#{AOL_NUM}/aol-6/en-us/Lite/ContactList.aspx?folder=Inbox&showUserFolders=False"
+    CONTACT_LIST_CSV_URL = "http://webmail1.mail.aol.com/#{AOL_NUM}/aol-6/en-us/Lite/ABExport.aspx?command=all"
+    PROTOCOL_ERROR       = "AOL has changed its protocols, please upgrade this library first. If that does not work, dive into the code and submit a patch at http://github.com/cardmagic/contacts"
     
     def real_connect
       if login.strip =~ /^(.+)@aol\.com$/ # strip off the @aol.com for AOL logins
@@ -80,7 +80,7 @@ class Contacts
         data, resp, cookies, forward, old_url = get(forward, cookies, old_url) + [forward]
       end
       
-      if data.index("Invalid Username or Password. Please try again.")
+      if data.index("Sign-in to this site requires JavaScript.")
         raise AuthenticationError, "Username and password do not match"
       elsif data.index("Required field must not be blank")
         raise AuthenticationError, "Login and password must not be blank"


### PR DESCRIPTION
Hei there,

I wanted to get rid of Hpricot in my project and saw that contacts had a hidden dependency on it. So I replaced the code using Hpricot to use Nokogiri instead. In addition, I made the dependency explicit and I fixed an issue with the AOL scraper (the only one using an XML parser). The tests pass.

cheers, Severin
