### PR TITLE
Fix for hotmail behind tinyproxy

### DIFF
--- a/lib/contacts/base.rb
+++ b/lib/contacts/base.rb
@@ -156,13 +156,19 @@ class Contacts
     
     def get(url, cookies="", referer="")
       url = URI.parse(url)
-      http = open_http(url)
-      resp, data = http.get("#{url.path}?#{url.query}",
-        "User-Agent" => "Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1) Gecko/20061010 Firefox/2.0",
-        "Accept-Encoding" => "gzip",
-        "Cookie" => cookies,
-        "Referer" => referer
-      )
+      attempt = 0
+      begin
+        http = open_http(url)
+        resp, data = http.get("#{url.path}?#{url.query}",
+          "User-Agent" => "Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1) Gecko/20061010 Firefox/2.0",
+          "Accept-Encoding" => "gzip",
+          "Cookie" => cookies,
+          "Referer" => referer
+        )
+      rescue EOFError => err
+        attempt += 1
+        retry if attempt == 1
+      end
       data = uncompress(resp, data)
       cookies = parse_cookies(resp.response['set-cookie'], cookies)
       forward = resp.response['Location']

--- a/lib/contacts/hotmail.rb
+++ b/lib/contacts/hotmail.rb
@@ -57,13 +57,6 @@ class Contacts
     
     def contacts(options = {})
       if connected?
-        url = URI.parse(contact_list_url)
-        data, resp, cookies, forward = get( contact_list_url, @cookies )
-        
-        if resp.code_type != Net::HTTPOK
-          raise ConnectionError, self.class.const_get(:PROTOCOL_ERROR)
-        end
-        
         @contacts = []
         build_contacts = []
         go = true
@@ -71,10 +64,9 @@ class Contacts
         
         while(go) do
           go = false
-          url = URI.parse(get_contact_list_url(index))
-          http = open_http(url)
-          resp, data = http.get(get_contact_list_url(index), "Cookie" => @cookies)
           
+          data, resp, cookies, forward = get( get_contact_list_url(index), @cookies )
+
           email_match_text_beginning = Regexp.escape("http://m.mail.live.com/?rru=compose&amp;to=")
           email_match_text_end = Regexp.escape("&amp;")
           


### PR DESCRIPTION
Retry a GET on EOFError (the case where a connection that should've had keep-alive broke)

We are using tinyproxy, and find that connections to hotmail don't remain connected as it seems they should.  This fixes it.
