### PR TITLE
Change dependency to greater than or equals on gdata version so ruby 1.9.2 will work

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,7 @@ spec = Gem::Specification.new do |s|
   s.autorequire = 'contacts'
 
   s.add_dependency('json', '>= 0.4.1')
-  s.add_dependency('gdata', '= 1.1.1')
+  s.add_dependency('gdata', '>= 1.1.1')
   s.requirements << "A json parser, the gdata ruby gem"
 
   #### Documentation and testing.


### PR DESCRIPTION
Change dependency to greater than or equals so that gdata 1.1.2 can be loaded and this library will work in ruby 1.9.2
